### PR TITLE
Refactor markdown creation to use a matrix

### DIFF
--- a/panel.html
+++ b/panel.html
@@ -15,11 +15,7 @@
 </head>
 <body>
   <div class="container">
-    This is where the UI is going to live.
-    Keep it simple with:
-    * A button to generate the markdown from the selected table.
     <button id="convert">Convert table to markdown</button>
-    * A textarea to display the markdown.
     <textarea name="markdown" id="markdown" cols="30" rows="10"></textarea>
   </div>
   <script src="panel.js"></script>

--- a/panel.js
+++ b/panel.js
@@ -1,8 +1,9 @@
 document.addEventListener('DOMContentLoaded', () => {
   document.querySelector('#convert').addEventListener('click', () => {
     let textarea = document.querySelector('#markdown')
-    chrome.devtools.inspectedWindow.eval(`(${convertToMarkdown.toString()})($0)`, markdown => {
-      if(markdown){
+    chrome.devtools.inspectedWindow.eval(`(${convertToMatrix.toString()})($0)`, matrix => {
+      if (matrix) {
+        let markdown = convertToMarkdown(matrix)
         textarea.value = markdown
       } else {
         // there was some sort of error
@@ -12,54 +13,64 @@ document.addEventListener('DOMContentLoaded', () => {
   })
 })
 
-const convertToMarkdown = table => {
+/**
+ * Returns a 2D array of the HTML table provided.
+ * @param {HTMLElement} table - the table to convert to a matrix.
+ */
+const convertToMatrix = table => {
   // if there's no node selected or if it's not a table, hop out
-  if(!table || table.nodeName.toLowercase() === "table"){
+  if (!table || !table.nodeName.toLowerCase() === "table") {
     return false
   }
   let header = table.querySelector('thead')
   let header_row = header.querySelector('tr')
   let table_body = table.querySelector('tbody')
 
-  let markdown = '|'
+  // Combine header row and body rows into an array
+  let rows = [header_row, ...table_body.children]
 
-  for (const header_column of header_row.children) {
-    markdown += header_column.innerText + '|'
-  }
+  // map every item into a matrix
+  let tableMatrix = rows.map(row => [...row.children].map(tableElement => tableElement.innerText))
 
-  markdown += '\n|---|---|---|---|\n'
-
-  for (let row of table_body.children) {
-    markdown += '|'
-    for (let column of row.children) {
-      markdown += column.innerText + '|'
-    }
-    markdown += '\n'
-  }
-
-  let rows = [header_row, table_body.children]
-
-  let tableMatrix = rows.map(row => {
-    row.children.map(tableElement => tableElement.innerText)
-  })
-
-  // we'll let the first row determine our column count
+  // let the first row (header) determine the column count
   let columnCount = tableMatrix[0].length
 
-  // create an array of 0s for current max width of each column
+  // create an array for current max width of each column, default to 0
   let columnWidths = Array(columnCount).fill(0)
 
   // look at each row
-  for (row of tableMatrix){
+  for (row of tableMatrix) {
     // check each column of that row
-    for (let column = 0; column < columnCount; column++){
+    for (let column = 0; column < columnCount; column++) {
       // if the length of this column item is the largest in its column
-      if (row[column].length > columnWidths[column]){
+      if (row[column].length > columnWidths[column]) {
         // set it as the new max column width
         columnWidths[column] = row[column].length
       }
     }
   }
+  return {
+    tableMatrix,
+    columnWidths
+  }
+}
+
+const convertToMarkdown = ({ tableMatrix, columnWidths }) => {
+  // TODO - allow for setting justification
+  let divider = columnWidths.map(columnWidth => '-'.repeat(columnWidth + 2))
+  // insert the divider after the header
+  tableMatrix.splice(1, 0, divider)
+
+  let markdown = tableMatrix.map(row => {
+    // create a row with all columns correctly spaced and joined together
+    let spacedRow = row.map((item, column) => {
+      let columnWidth = columnWidths[column] + 2
+      let leftSpace = ' '.repeat(Math.floor((columnWidth - item.length) / 2))
+      let rightSpace = ' '.repeat(Math.ceil((columnWidth - item.length) / 2))
+      return leftSpace + item + rightSpace
+    }).join('|')
+    return `|${spacedRow}|`
+  }).join('\n')
 
   return markdown
 }

--- a/panel.js
+++ b/panel.js
@@ -13,8 +13,8 @@ document.addEventListener('DOMContentLoaded', () => {
 })
 
 const convertToMarkdown = table => {
-  // if there's no node selected, hop out
-  if(!table){
+  // if there's no node selected or if it's not a table, hop out
+  if(!table || table.nodeName.toLowercase() === "table"){
     return false
   }
   let header = table.querySelector('thead')
@@ -36,5 +36,30 @@ const convertToMarkdown = table => {
     }
     markdown += '\n'
   }
+
+  let rows = [header_row, table_body.children]
+
+  let tableMatrix = rows.map(row => {
+    row.children.map(tableElement => tableElement.innerText)
+  })
+
+  // we'll let the first row determine our column count
+  let columnCount = tableMatrix[0].length
+
+  // create an array of 0s for current max width of each column
+  let columnWidths = Array(columnCount).fill(0)
+
+  // look at each row
+  for (row of tableMatrix){
+    // check each column of that row
+    for (let column = 0; column < columnCount; column++){
+      // if the length of this column item is the largest in its column
+      if (row[column].length > columnWidths[column]){
+        // set it as the new max column width
+        columnWidths[column] = row[column].length
+      }
+    }
+  }
+
   return markdown
 }


### PR DESCRIPTION
By storing the table first in a matrix instead of converting immediately to a string, I can manipulate the cells individually to pretty print the markdown output.