### PR TITLE
Add an options dropdown menu

### DIFF
--- a/panel.css
+++ b/panel.css
@@ -115,12 +115,21 @@ h2 {
 }
 
 .options {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: flex-start;
+  margin-top: 5px;
   position: relative;
   overflow: hidden;
   opacity: 1;
   transform: translate(0,0);
   z-index: 2;
   transition: all 0.25s ease-in-out;
+}
+
+.options label {
+  font-size: 16px;
 }
 
 @keyframes flipdown {

--- a/panel.html
+++ b/panel.html
@@ -32,6 +32,10 @@
             <input type="checkbox" name="blank-header" id="blank-header">
             Leave the header blank
           </label>
+          <label for="no-pretty-print">
+            <input type="checkbox" name="no-pretty-print" id="no-pretty-print">
+            Disable pretty printing
+          </label>
         </div>
       </div>
     </div>

--- a/panel.js
+++ b/panel.js
@@ -106,8 +106,15 @@ const convertToMarkdown = ({ tableMatrix, columnWidths }) => {
     tableMatrix.unshift(Array(columnWidths.length).fill(''))
   }
 
+  // This setting will remove all the extra spaces in the markdown table used to make things look nice.
+  let noPrettyPrint = document.querySelector("#no-pretty-print").checked
+
   // Create the divider row that sits beneath the header
   let divider = columnWidths.map(columnWidth => {
+    // stick to the minimum 3 if pretty printing turned off
+    if(noPrettyPrint){
+      return '---'
+    }
     // (columnWidth || 1) ensures we'll always have at least 3 dashes, a req. for markdown
     return '-'.repeat((columnWidth || 1) + 2)
   })
@@ -117,6 +124,10 @@ const convertToMarkdown = ({ tableMatrix, columnWidths }) => {
   let markdown = tableMatrix.map(row => {
     // create a row with all columns correctly spaced and joined together
     let spacedRow = row.map((item, column) => {
+      // skip adding spaces if pretty print is turned off
+      if (noPrettyPrint) {
+        return item
+      }
       let columnWidth = columnWidths[column] + 2
       let leftSpace = ' '.repeat(Math.floor((columnWidth - item.length) / 2))
       let rightSpace = ' '.repeat(Math.ceil((columnWidth - item.length) / 2))


### PR DESCRIPTION
This options dropdown menu currently provides two customization options:
- remove the pretty printing from the markdown output
- leave a blank header